### PR TITLE
Changes: fix activation view filling the whole screen in horizontal orientation and some others...

### DIFF
--- a/app/src/main/java/de/devmil/paperlaunch/SettingsActivity.kt
+++ b/app/src/main/java/de/devmil/paperlaunch/SettingsActivity.kt
@@ -64,8 +64,8 @@ class SettingsActivity : Activity() {
                 activationIndicatorView,
                 this,
                 ViewUtils.getPxFromDip(this, us.sensitivityDip.toFloat()).toInt(),
-                ViewUtils.getPxFromDip(this, us.activationOffsetPositionDip.toFloat()).toInt(),
-                ViewUtils.getPxFromDip(this, us.activationOffsetHeightDip.toFloat()).toInt(),
+                us.activationOffsetPosition,
+                us.activationHeightPercent,
                 us.isOnRightSide,
                 ContextCompat.getColor(this, R.color.theme_accent)
         )

--- a/app/src/main/java/de/devmil/paperlaunch/config/IUserSettings.kt
+++ b/app/src/main/java/de/devmil/paperlaunch/config/IUserSettings.kt
@@ -17,8 +17,6 @@ package de.devmil.paperlaunch.config
 
 interface IUserSettings {
 
-    val activationOffsetHeightDip: Int
-    val activationOffsetPositionDip: Int
     val sensitivityDip: Int
     val isOnRightSide: Boolean
     val isShowBackground: Boolean
@@ -26,4 +24,8 @@ interface IUserSettings {
     val launcherGravity: LauncherGravity?
     val showLogo: Boolean
     val itemScalePercent: Int
+    val activationHeightPercent: Int
+    val activationOffsetPosition: Int
+    val isShowHint : Boolean
+
 }

--- a/app/src/main/java/de/devmil/paperlaunch/config/LaunchConfig.kt
+++ b/app/src/main/java/de/devmil/paperlaunch/config/LaunchConfig.kt
@@ -46,15 +46,17 @@ class LaunchConfig(userSettings: IUserSettings) : ILaunchEntryConfig, ILaunchLan
     val launcherBackgroundAlpha = 0.3f
     val launcherBackgroundAnimationDurationMS = 250
     val maxFolderDepth = 9
+    val launcherHintAlpha = 0.28f
 
     //UserSettings
     @Suppress("JoinDeclarationAndAssignment")
     val launcherSensitivityDip: Int
     override val isOnRightSide: Boolean
-    val launcherOffsetPositionDip: Int
-    val launcherOffsetHeightDip: Int
     val showLauncherBackground: Boolean
     val isVibrateOnActivation: Boolean
+    val launcherOffsetPosition: Int
+    val launcherHeightPercent: Int
+    val showLauncherHint : Boolean
     override val launcherGravity: LauncherGravity?
     override val imageWidthDip: Float
     override val showLogo: Boolean
@@ -68,12 +70,13 @@ class LaunchConfig(userSettings: IUserSettings) : ILaunchEntryConfig, ILaunchLan
     init {
         launcherSensitivityDip = userSettings.sensitivityDip
         isOnRightSide = userSettings.isOnRightSide
-        launcherOffsetPositionDip = userSettings.activationOffsetPositionDip
-        launcherOffsetHeightDip = userSettings.activationOffsetHeightDip
         showLauncherBackground = userSettings.isShowBackground
         isVibrateOnActivation = userSettings.isVibrateOnActivation
         launcherGravity = userSettings.launcherGravity
         imageWidthDip = (BASE_IMAGE_WIDTH_DIP * userSettings.itemScalePercent) / 100f
         showLogo = userSettings.showLogo
+        showLauncherHint = userSettings.isShowHint
+        launcherOffsetPosition = userSettings.activationOffsetPosition
+        launcherHeightPercent = userSettings.activationHeightPercent
     }
 }

--- a/app/src/main/java/de/devmil/paperlaunch/config/UserSettings.kt
+++ b/app/src/main/java/de/devmil/paperlaunch/config/UserSettings.kt
@@ -21,14 +21,16 @@ class UserSettings(context: Context) : IUserSettings {
 
 
     override var sensitivityDip: Int = 0
-    override var activationOffsetPositionDip: Int = 0
-    override var activationOffsetHeightDip: Int = 0
     override var isShowBackground: Boolean = false
     override var isVibrateOnActivation: Boolean = false
     override var isOnRightSide: Boolean = false
     override var launcherGravity: LauncherGravity = LauncherGravity.Center
     override var showLogo: Boolean = true
     override var itemScalePercent: Int = 100
+    override var activationOffsetPosition: Int = 0
+    override var activationHeightPercent: Int = 0
+    override var isShowHint: Boolean = false
+
 
     init {
         load(context)
@@ -37,28 +39,30 @@ class UserSettings(context: Context) : IUserSettings {
     fun load(context: Context) {
         val prefs = context.getSharedPreferences(SHARED_PREFS_NAME, Context.MODE_PRIVATE)
         sensitivityDip = prefs.getInt(KEY_SENSITIVITY_DIP, DEFAULT_SENSITIVITY_DIP)
-        activationOffsetPositionDip = prefs.getInt(KEY_ACTIVATION_OFFSET_POSITION_DIP, DEFAULT_ACTIVATION_OFFSET_POSITION_DIP)
-        activationOffsetHeightDip = prefs.getInt(KEY_ACTIVATION_OFFSET_HEIGHT_DIP, DEFAULT_ACTIVATION_OFFSET_HEIGHT_DIP)
         isShowBackground = prefs.getBoolean(KEY_SHOW_BACKGROUND, DEFAULT_SHOW_BACKGROUND)
         isVibrateOnActivation = prefs.getBoolean(KEY_VIBRATE_ON_ACTIVATION, DEFAULT_VIBRATE_ON_ACTIVATION)
         isOnRightSide = prefs.getBoolean(KEY_IS_ON_RIGHT_SIDE, DEFAULT_IS_ON_RIGHT_SIDE)
         launcherGravity = LauncherGravity.fromValue(prefs.getInt(KEY_LAUNCHER_GRAVITY, DEFAULT_LAUNCHER_GRAVITY.value))
         showLogo = prefs.getBoolean(KEY_SHOW_LOGO, DEFAULT_SHOW_LOGO)
         itemScalePercent = prefs.getInt(KEY_ITEM_SCALE_PERCENT, DEFAULT_ITEM_SCALE_PERCENT)
+        activationOffsetPosition = prefs.getInt(KEY_ACTIVATION_OFFSET_POSITION, DEFAULT_ACTIVATION_OFFSET_POSITION)
+        activationHeightPercent = prefs.getInt(KEY_ACTIVATION_HEIGHT_PERCENT, DEFAULT_ACTIVATION_HEIGHT_PERCENT)
+        isShowHint = prefs.getBoolean(KEY_IS_SHOW_HINT, DEFAULT_SHOW_HINT)
     }
 
     fun save(context: Context) {
         val prefs = context.getSharedPreferences(SHARED_PREFS_NAME, Context.MODE_PRIVATE)
         prefs.edit()
                 .putInt(KEY_SENSITIVITY_DIP, sensitivityDip)
-                .putInt(KEY_ACTIVATION_OFFSET_POSITION_DIP, activationOffsetPositionDip)
-                .putInt(KEY_ACTIVATION_OFFSET_HEIGHT_DIP, activationOffsetHeightDip)
                 .putBoolean(KEY_SHOW_BACKGROUND, isShowBackground)
                 .putBoolean(KEY_VIBRATE_ON_ACTIVATION, isVibrateOnActivation)
                 .putBoolean(KEY_IS_ON_RIGHT_SIDE, isOnRightSide)
                 .putInt(KEY_LAUNCHER_GRAVITY, launcherGravity.value)
                 .putBoolean(KEY_SHOW_LOGO, showLogo)
                 .putInt(KEY_ITEM_SCALE_PERCENT, itemScalePercent)
+                .putBoolean(KEY_IS_SHOW_HINT, isShowHint)
+                .putInt(KEY_ACTIVATION_OFFSET_POSITION, activationOffsetPosition)
+                .putInt(KEY_ACTIVATION_HEIGHT_PERCENT, activationHeightPercent)
                 .apply()
     }
 
@@ -67,23 +71,26 @@ class UserSettings(context: Context) : IUserSettings {
         internal val SHARED_PREFS_NAME = "paperLaunch"
 
         internal val KEY_SENSITIVITY_DIP = "sensitivityDip"
-        internal val KEY_ACTIVATION_OFFSET_POSITION_DIP = "activationOffsetPositionDip"
-        internal val KEY_ACTIVATION_OFFSET_HEIGHT_DIP = "activationOffsetHeightDip"
         internal val KEY_SHOW_BACKGROUND = "showBackground"
         internal val KEY_VIBRATE_ON_ACTIVATION = "vibrateOnActivation"
         internal val KEY_IS_ON_RIGHT_SIDE = "isOnRightSide"
         internal val KEY_LAUNCHER_GRAVITY = "launcherGravity"
         internal val KEY_SHOW_LOGO = "showLogo"
         internal val KEY_ITEM_SCALE_PERCENT = "itemScalePercent"
+        internal val KEY_ACTIVATION_OFFSET_POSITION = "activationOffsetPosition"
+        internal val KEY_ACTIVATION_HEIGHT_PERCENT = "activationHeightPercent"
+        internal val KEY_IS_SHOW_HINT = "isShowHint"
+
 
         private val DEFAULT_SENSITIVITY_DIP = 10
-        private val DEFAULT_ACTIVATION_OFFSET_POSITION_DIP = 0
-        private val DEFAULT_ACTIVATION_OFFSET_HEIGHT_DIP = 0
         private val DEFAULT_SHOW_BACKGROUND = false
         private val DEFAULT_VIBRATE_ON_ACTIVATION = false
         private val DEFAULT_IS_ON_RIGHT_SIDE = true
         private val DEFAULT_LAUNCHER_GRAVITY = LauncherGravity.Center
         private val DEFAULT_SHOW_LOGO = true
         private val DEFAULT_ITEM_SCALE_PERCENT = 100
+        private val DEFAULT_SHOW_HINT = false
+        private val DEFAULT_ACTIVATION_OFFSET_POSITION = 0
+        private val DEFAULT_ACTIVATION_HEIGHT_PERCENT = 25
     }
 }

--- a/app/src/main/java/de/devmil/paperlaunch/service/LauncherOverlayService.kt
+++ b/app/src/main/java/de/devmil/paperlaunch/service/LauncherOverlayService.kt
@@ -23,12 +23,15 @@ import android.content.IntentFilter
 import android.graphics.Color
 import android.graphics.PixelFormat
 import android.graphics.Rect
+import android.graphics.drawable.ShapeDrawable
+import android.graphics.drawable.shapes.RoundRectShape
 import android.os.Build
 import android.os.IBinder
 import android.os.VibrationEffect
 import android.os.Vibrator
 import android.support.annotation.RequiresApi
 import android.support.v4.app.NotificationCompat
+import android.support.v4.content.ContextCompat
 import android.util.DisplayMetrics
 import android.util.Log
 import android.view.Gravity
@@ -376,14 +379,25 @@ class LauncherOverlayService : Service() {
 
     @Synchronized private fun reloadTouchReceiver() {
 
+        val showLauncherHint = currentConfig!!.showLauncherHint
+        val colorAccent = ContextCompat.getColor(this, R.color.theme_accent)
+        val backgroundColor =   if(showLauncherHint)
+                                    Color.argb(
+                                        (currentConfig!!.launcherHintAlpha * 0xff).toInt(),
+                                        Color.red(colorAccent),
+                                        Color.green(colorAccent),
+                                        Color.blue(colorAccent) )
+                                else Color.TRANSPARENT
+
         val avr = addActivationViewToWindow(
                 touchReceiverView,
                 this,
                 ViewUtils.getPxFromDip(this, currentConfig!!.launcherSensitivityDip.toFloat()).toInt(),
-                ViewUtils.getPxFromDip(this, currentConfig!!.launcherOffsetPositionDip.toFloat()).toInt(),
-                ViewUtils.getPxFromDip(this, currentConfig!!.launcherOffsetHeightDip.toFloat()).toInt(),
+                currentConfig!!.launcherOffsetPosition,
+                currentConfig!!.launcherHeightPercent,
                 currentConfig!!.isOnRightSide,
-                Color.TRANSPARENT)
+                backgroundColor
+        )
 
         if(!avr.success) {
             return
@@ -630,13 +644,29 @@ class LauncherOverlayService : Service() {
             @Suppress("RtlHardcoded")
             params.gravity = Gravity.LEFT or Gravity.TOP
 
+            val cornerRadius = 20.0f
+            val activationBg = ShapeDrawable().apply {
+                shape = RoundRectShape(
+                    floatArrayOf(cornerRadius,cornerRadius,.0f,.0f,.0f,.0f,cornerRadius,cornerRadius),
+                    null,
+                    null)
+                paint.color = backgroundColor
+            }
             result.activationView = LinearLayout(context)
-            result.activationView!!.setBackgroundColor(backgroundColor)
+            result.activationView!!.background = activationBg
 
             val touchReceiverParams = LinearLayout.LayoutParams(
                     activationRect.width(),
                     activationRect.height())
             touchReceiverParams.setMargins(0, activationRect.top, 0, windowRect.height() - activationRect.bottom)
+
+            // Prevent conflicting with system's back gesture starting Android 10
+            val exclusionRects = mutableListOf<Rect>()
+            val exclusionRect = Rect(0, 0,activationRect.width(), activationRect.height())
+            exclusionRects.add(exclusionRect)
+            if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q){ // Android 10 and up
+                result.activationView!!.systemGestureExclusionRects = exclusionRects
+            }
 
             wm.addView(result.activationView, params)
 

--- a/app/src/main/java/de/devmil/paperlaunch/utils/ActivationIndicatorHelper.kt
+++ b/app/src/main/java/de/devmil/paperlaunch/utils/ActivationIndicatorHelper.kt
@@ -37,15 +37,14 @@ object ActivationIndicatorHelper {
             right = left + sensitivity
         }
 
-        val height = availableRect.height() - offsetSize
-        top += offsetPosition + offsetSize / 2
+        val height = (availableRect.height() * (offsetSize/100.0f)).toInt()
+
+        // top += (center Y of the window) - (half the view height) + ( (position range) * position percentage)
+        top += ((availableRect.height()/2) - (height / 2) + ( (availableRect.height()-height) * offsetPosition/100.0f) ).toInt()
+
         bottom = top + height
 
         val result = Rect(left, top, right, bottom)
-
-        if (!result.intersect(availableRect)) {
-            return availableRect
-        }
 
         return result
     }

--- a/app/src/main/java/de/devmil/paperlaunch/view/fragments/SettingsFragment.kt
+++ b/app/src/main/java/de/devmil/paperlaunch/view/fragments/SettingsFragment.kt
@@ -89,34 +89,29 @@ class SettingsFragment : PreferenceFragment() {
         val metrics = DisplayMetrics()
         activity.windowManager.defaultDisplay.getMetrics(metrics)
 
-        val heightDpi = metrics.heightPixels / metrics.density
-
-        val offsetHeightPreference = SeekBarPreference(context, 0, heightDpi.toInt())
+        val offsetHeightPreference = SeekBarPreference(context, 0, 100)
         activationCategory.addPreference(offsetHeightPreference)
 
-        offsetHeightPreference.setValue(heightDpi.toInt() - userSettings!!.activationOffsetHeightDip)
+        offsetHeightPreference.setValue(userSettings!!.activationHeightPercent)
         offsetHeightPreference.setTitle(R.string.fragment_settings_activation_offset_height_title)
         offsetHeightPreference.isPersistent = false
         offsetHeightPreference.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, newValue ->
             userSettings!!.load(activity)
-            userSettings!!.activationOffsetHeightDip = heightDpi.toInt() - newValue as Int
+            userSettings!!.activationHeightPercent = newValue as Int
             userSettings!!.save(activity)
             fireActivationParametersChanged()
             true
         }
 
-        val offsetMin = -(heightDpi / 2).toInt()
-        val offsetMax = (heightDpi / 2).toInt()
-
-        val offsetPositionPreference = SeekBarPreference(context, offsetMin, offsetMax)
+        val offsetPositionPreference = SeekBarPreference(context, -50,50) // 0 is center of the window's height
         activationCategory.addPreference(offsetPositionPreference)
 
-        offsetPositionPreference.setValue(userSettings!!.activationOffsetPositionDip)
+        offsetPositionPreference.setValue(userSettings!!.activationOffsetPosition)
         offsetPositionPreference.setTitle(R.string.fragment_settings_activation_offset_position_title)
         offsetPositionPreference.isPersistent = false
         offsetPositionPreference.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, newValue ->
             userSettings!!.load(activity)
-            userSettings!!.activationOffsetPositionDip = newValue as Int
+            userSettings!!.activationOffsetPosition = newValue as Int
             userSettings!!.save(activity)
             fireActivationParametersChanged()
             true
@@ -137,6 +132,26 @@ class SettingsFragment : PreferenceFragment() {
             LauncherOverlayService.notifyConfigChanged(activity)
             true
         }
+
+        val showActivationHintPreference = CheckBoxPreference(context)
+        activationCategory.addPreference(showActivationHintPreference)
+
+        val isShowHint = userSettings!!.isShowHint
+        showActivationHintPreference.isChecked = isShowHint
+
+        showActivationHintPreference.setTitle(R.string.fragment_settings_activation_show_hint_title)
+        showActivationHintPreference.setSummaryOn(R.string.fragment_settings_activation_show_hint_summary_on)
+        showActivationHintPreference.setSummaryOff(R.string.fragment_settings_activation_show_hint_summary_off)
+        showActivationHintPreference.isPersistent = false
+        showActivationHintPreference.onPreferenceChangeListener = Preference.OnPreferenceChangeListener{ _, newValue ->
+            userSettings!!.load(activity)
+            userSettings!!.isShowHint = newValue as Boolean
+            userSettings!!.save(activity)
+            LauncherOverlayService.notifyConfigChanged(activity)
+
+            true
+        }
+
     }
 
     private fun addAppearanceSettings(context: Context, screen: PreferenceScreen) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,4 +90,7 @@
     <string name="activity_edit_setting_description_enable">Activate</string>
     <string name="activity_edit_setting_description_disable">Pause</string>
     <string name="activity_edit_setting_new_paperlaunch_state">New PaperLaunch state:</string>
+    <string name="fragment_settings_activation_show_hint_title">Show activation hint</string>
+    <string name="fragment_settings_activation_show_hint_summary_on">Activation hint is shown</string>
+    <string name="fragment_settings_activation_show_hint_summary_off">Activation hint is not shown</string>
 </resources>


### PR DESCRIPTION
This PR fixes `activation view` filling the whole screen when device's orientation changes to horizontal. The culprit behind this was in `ActivationIndicatorHelper.calculateActivationIndicatorSize()`.  The `if(!result.intersect(availableRect))` always returned `false`, causing `calculateActivationIndicatorSize()` returns with `availableRect` instead of the `result` rect. This caused it to fill the whole screen.

And the reason it was always intersecting was that the `Height` slider setting's maxValue was set to a fixed `heightDpi.toInt()`. And this `heightDpi.toInt()` was fetched during previous device's orientation, which is in most cases in vertical mode. And when the orientation changes this `height` value can intersect with the newly calculated size in `calculateIndicatorSize()`. 

The PR also includes:
- Prevent `activation view` conflicting with android's back gesture starting Android 10
- Add option to display hint in the activation area
  